### PR TITLE
Remove reliance on CamelCase component names

### DIFF
--- a/flake8_idom/utils.py
+++ b/flake8_idom/utils.py
@@ -30,12 +30,18 @@ def is_hook_def(node: ast.FunctionDef) -> bool:
 
 
 def is_component_def(node: ast.FunctionDef) -> bool:
-    return is_component_function_name(node.name)
-
-
-def is_component_function_name(name: str) -> bool:
-    return name[0].upper() == name[0] and "_" not in name
+    return any(
+        decorator.value.id == "idom" and decorator.attr == "component"
+        for decorator in node.decorator_list
+    )
 
 
 def is_hook_function_name(name: str) -> bool:
-    return name.lstrip("_").startswith("use_")
+    return name.lstrip("_") in {
+        "use_state",
+        "use_effect",
+        "use_memo",
+        "use_reducer",
+        "use_callback",
+        "use_ref",
+    }


### PR DESCRIPTION
`is_component_def` now checks if a function is decorated with `@idom.component` to determine whether something is a component.

This implementation also works if directly using `@component` as a decorator.

Also, all hook names are now explicitly stated rather than implicitly assuming everything `use_*` is a hook.